### PR TITLE
System prompt templates

### DIFF
--- a/DotPrompt.Tests/SamplePrompts/basic-sp-template.prompt
+++ b/DotPrompt.Tests/SamplePrompts/basic-sp-template.prompt
@@ -1,0 +1,23 @@
+config:
+  outputFormat: text
+  temperature: 0.9
+  maxTokens: 500
+  input:
+    parameters:
+      country: string
+      style?: string
+      generated?: datetime
+    default:
+      country: Malta
+prompts:
+  system: |-
+    You are a helpful AI assistant that who has extensive local knowledge of {{ country }}
+    {% if generated -%}
+    You should append each response with the text `Generated: <date>` where `<date>` is replaced with the current date, for example:
+    `Generated: {{ generated | format_date:"dddd d MMM yyyy", "en-gb" }}`
+    {% endif -%}
+  user: |
+    I am looking at going on holiday to {{ country }} and would like to know more about it, what can you tell me?
+    {% if style -%}
+    Can you answer in the style of a {{ style }}
+    {% endif -%}

--- a/DotPrompt/Extensions/OpenAi/OpenAiExtensions.cs
+++ b/DotPrompt/Extensions/OpenAi/OpenAiExtensions.cs
@@ -18,7 +18,7 @@ public static class OpenAiExtensions
     {
         var messages = new List<ChatMessage>();
 
-        // If the prompt file provides any few shot prompts then include these first
+        // If the prompt file provides any few shot prompts, then include these first
         if (promptFile.FewShots.Length != 0)
         {
             foreach (var fewShot in promptFile.FewShots)
@@ -30,7 +30,7 @@ public static class OpenAiExtensions
 
         if (!string.IsNullOrEmpty(promptFile.Prompts!.System))
         {
-            messages.Add(new SystemChatMessage(promptFile.GetSystemPrompt()));
+            messages.Add(new SystemChatMessage(promptFile.GetSystemPrompt(values)));
         }
         
         messages.Add(new UserChatMessage(promptFile.GetUserPrompt(values)));

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ using DotPrompt;
 
 var promptFile = PromptFile.FromFile("path/to/prompt-file.prompt");
 
-var systemPrompt = promptFile.GetSystemPrompt();
+var systemPrompt = promptFile.GetSystemPrompt(null);
 var userPrompt = promptFile.GetUserPrompt(new Dictionary<string, object>
 {
     { "topic", "bluetooth" },
@@ -146,7 +146,9 @@ var client = openAiClient.GetChatClient("model");
 
 var promptFile = PromptFile.FromFile("path/to/prompt-file.prompt");
 
-var systemPrompt = promptFile.GetSystemPrompt();
+// The system prompt and user prompt methods take dictionaries containing the values needed for the
+// template. If none are needed you can simply pass in null.
+var systemPrompt = promptFile.GetSystemPrompt(null);
 var userPrompt = promptFile.GetUserPrompt(new Dictionary<string, object>
 {
     { "topic", "bluetooth" },


### PR DESCRIPTION
This adds the ability to use the Fluid templating language with system prompts as well. The parameters remain consistent for the prompt file rather than requiring a second set of parameters. The OpenAI extensions simply pass in the provided values to both method calls.

While adding the new tests, also converted some existing ones to Theory tests to avoid duplication