### PR TITLE
Provide override for using a different path with the prompt manager

### DIFF
--- a/DotPrompt.Tests/PromptManagerTests.cs
+++ b/DotPrompt.Tests/PromptManagerTests.cs
@@ -16,10 +16,23 @@ public class PromptManagerTests
     }
 
     [Fact]
-    public void PromptManager_WithPathSpecified_LoadsPromptsFromSpecifiedLocation()
+    public void PromptManager_WithFilePromptStoreSpecified_LoadsPromptsFromSpecifiedLocation()
     {
         var promptStore = new FilePromptStore("manager-prompts");
         var manager = new PromptManager(promptStore);
+
+        var expectedPrompts = new List<string> { "basic", "example-with-name" };
+        var actualPrompts = manager.ListPromptFileNames().ToList();
+        
+        Assert.Equal(expectedPrompts.Count, actualPrompts.Count);
+        Assert.Contains("basic", actualPrompts);
+        Assert.Contains("example-with-name", actualPrompts);
+    }
+
+    [Fact]
+    public void PromptManager_WithPathSpecified_LoadsPromptsFromSpecifiedLocation()
+    {
+        var manager = new PromptManager("manager-prompts");
 
         var expectedPrompts = new List<string> { "basic", "example-with-name" };
         var actualPrompts = manager.ListPromptFileNames().ToList();

--- a/DotPrompt/PromptManager.cs
+++ b/DotPrompt/PromptManager.cs
@@ -14,6 +14,13 @@ public class PromptManager : IPromptManager
     /// <see cref="FilePromptStore"/>
     /// </summary>
     public PromptManager() : this(new FilePromptStore()) { }
+    
+    /// <summary>
+    /// Creates a new instance of the <see cref="PromptManager"/> using the provided path for an
+    /// instance of the <see cref="FilePromptStore"/>
+    /// </summary>
+    /// <param name="path">The path to the directory containing the prompt files</param>
+    public PromptManager(string path) : this(new FilePromptStore(path)) { }
 
     /// <summary>
     /// Creates a new instance of the <see cref="PromptManager"/> class which loads the .prompt files from a

--- a/README.md
+++ b/README.md
@@ -176,8 +176,7 @@ var promptManager = new PromptManager();
 var promptFile = promptManager.GetPromptFile("example");
 
 // Use a different folder
-var filePromptStore = new FilePromptStore("another-location");
-var promptManager = new PromptManager(filePromptStore);
+var promptManager = new PromptManager("another-location");
 
 var promptFile = promptManager.GetPromptFile("example");
 
@@ -187,7 +186,7 @@ var promptNames = promptManager.ListPromptFileNames();
 
 The prompt manager implements an `IPromptManager` interface, and so if you want to use this through a DI container, or IoC pattern, then you can easily provide a mocked version for testing.
 
-In the above you can see that the prompt manager is taking a `FilePromptStore` type, this is a class which implements the `IPromptStore` type and comes with the library. But, if you want, you can implement your own version which can read in prompt files from other locations. So if you want to store your prompts in a database, on a cloud-based storage service, or anything else, you can. The prompt manager will call the `Load` method and use it to collect the prompts, then you can continue working as usual.
+The prompt manager can also take an `IPromptStore` instance which allows you to build a custom store which might not be file-based (see [Creating a custom prompt store](#creating-a-custom-prompt-store)). This also allows for providing a mocked interface so you can write unit tests which are not dependent on the storage mechanism.
 
 ### Full examples
 


### PR DESCRIPTION
Added a new constructor overload for PromptManager to accept a directory path as a parameter, simplifying initialization when using a FilePromptStore. Updated README to reflect this change and added relevant unit tests to ensure correct behavior.