### PR TITLE
Refactor test to use variables for prompt file name

### DIFF
--- a/DotPrompt.Tests/PromptFileTests.cs
+++ b/DotPrompt.Tests/PromptFileTests.cs
@@ -178,9 +178,9 @@ public class PromptFileTests
         using var ms = new MemoryStream(Encoding.UTF8.GetBytes(content));
         ms.Seek(0, SeekOrigin.Begin);
 
-        var promptFile = PromptFile.FromStream("clean\r\n\r\nthis name", ms);
+        var promptFile = PromptFile.FromStream(inputName, ms);
 
-        Assert.Equal("clean-this-name", promptFile.Name);
+        Assert.Equal(expectedName, promptFile.Name);
     }
 
     [Fact]


### PR DESCRIPTION
Updated the test to utilize `inputName` and `expectedName` variables instead of hardcoded strings.

(I did a stupid)