### PR TITLE
Implement support for versioned prompt files

### DIFF
--- a/DotPrompt.Tests/DotPrompt.Tests.csproj
+++ b/DotPrompt.Tests/DotPrompt.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/DotPrompt.Tests/DotPrompt.Tests.csproj
+++ b/DotPrompt.Tests/DotPrompt.Tests.csproj
@@ -35,6 +35,9 @@
     <None Update="duplicate-name-prompts\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="multiple-version-prompts\*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/DotPrompt.Tests/PromptFileTests.cs
+++ b/DotPrompt.Tests/PromptFileTests.cs
@@ -213,6 +213,30 @@ public class PromptFileTests
         Assert.Null(promptFile.Model);
     }
 
+    [Theory]
+    [InlineData(int.MinValue, true)]
+    [InlineData(-1, true)]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    public void FromStream_WithInvalidVersion_ThrowsAnException(int version, bool throwsException)
+    {
+        var content = $"name: test\nversion: {version}\nprompts:\n  system: System prompt\n  user: User prompt";
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        ms.Seek(0, SeekOrigin.Begin);
+        
+        var act = () => PromptFile.FromStream("test", ms);
+
+        if (throwsException)
+        {
+            var exception = Assert.Throws<DotPromptException>(act);
+            Assert.Contains("The version of the prompt file cannot be negative", exception.Message);
+        }
+        else
+        {
+            act();
+        }
+    }
+
     [Fact]
     public void GenerateUserPrompt_UsingDefaults_CorrectlyGeneratesPromptFromTemplate()
     {

--- a/DotPrompt.Tests/PromptFileTests.cs
+++ b/DotPrompt.Tests/PromptFileTests.cs
@@ -368,7 +368,7 @@ public class PromptFileTests
             }
         };
 
-        var expected = "name: test\nconfig:\n  input:\n    parameters:\n      test?: string\n  outputFormat: Json\n  maxTokens: 500\nprompts:\n  system: system prompt\n  user: user prompt\n";
+        const string expected = "name: test\nversion: 1\nconfig:\n  input:\n    parameters:\n      test?: string\n  outputFormat: Json\n  maxTokens: 500\nprompts:\n  system: system prompt\n  user: user prompt\n";
 
         var ms = new MemoryStream();
         promptFile.ToStream(ms);

--- a/DotPrompt.Tests/PromptFileTests.cs
+++ b/DotPrompt.Tests/PromptFileTests.cs
@@ -21,6 +21,7 @@ public class PromptFileTests
         };
         
         Assert.Equal("basic", promptFile.Name);
+        Assert.Equal(1, promptFile.Version);
         
         Assert.NotNull(promptFile.Model);
         Assert.Equal("claude-3-5-sonnet-latest", promptFile.Model);

--- a/DotPrompt.Tests/PromptManagerTests.cs
+++ b/DotPrompt.Tests/PromptManagerTests.cs
@@ -84,6 +84,39 @@ public class PromptManagerTests
     }
 
     [Fact]
+    public void PromptManager_WhenRequestedByName_ReturnsLatestVersion()
+    {
+        var manager = new PromptManager("multiple-version-prompts");
+        
+        var expectedPrompt = PromptFile.FromFile("multiple-version-prompts/basic-new.prompt");
+        var actualPrompt = manager.GetPromptFile("basic");
+        
+        Assert.Equivalent(expectedPrompt, actualPrompt, strict: true);
+    }
+
+    [Fact]
+    public void PromptManager_WhenRequestedByNameAndVersion_ReturnsCorrectVersion()
+    {
+        var manager = new PromptManager("multiple-version-prompts");
+        
+        var expectedPrompt = PromptFile.FromFile("multiple-version-prompts/basic.prompt");
+        var actualPrompt = manager.GetPromptFile("basic", 1);
+        
+        Assert.Equivalent(expectedPrompt, actualPrompt, strict: true);
+    }
+    
+    [Fact]
+    public void PromptManager_WhenRequestedByNameAndInvalidVersion_ThrowsException()
+    {
+        var manager = new PromptManager("multiple-version-prompts");
+        
+        var act = () => manager.GetPromptFile("basic", 3);
+        
+        var exception = Assert.Throws<DotPromptException>(act);
+        Assert.Equal("No prompt file with that name and version has been loaded", exception.Message);   
+    }
+
+    [Fact]
     public void GetPromptFile_WhenRequestedWithValidName_LoadsExpectedPromptFile()
     {
         var manager = new PromptManager();

--- a/DotPrompt.Tests/PromptManagerTests.cs
+++ b/DotPrompt.Tests/PromptManagerTests.cs
@@ -69,6 +69,21 @@ public class PromptManagerTests
     }
 
     [Fact]
+    public void PromptManager_WithDifferentVersions_LoadsSuccessfully()
+    {
+        var manager = new PromptManager("multiple-version-prompts");
+        
+        var expectedPrompts = new List<string> { "basic:1", "basic:2" };
+        var actualPrompts = manager.ListPromptFileNamesWithVersions().ToList();
+        
+        Assert.Equal(expectedPrompts.Count, actualPrompts.Count);
+        foreach (var expectedPrompt in expectedPrompts)
+        {
+            Assert.Contains(expectedPrompt, actualPrompts);
+        }
+    }
+
+    [Fact]
     public void GetPromptFile_WhenRequestedWithValidName_LoadsExpectedPromptFile()
     {
         var manager = new PromptManager();

--- a/DotPrompt.Tests/PromptManagerTests.cs
+++ b/DotPrompt.Tests/PromptManagerTests.cs
@@ -41,6 +41,21 @@ public class PromptManagerTests
         Assert.Contains("basic", actualPrompts);
         Assert.Contains("example-with-name", actualPrompts);
     }
+    
+    [Fact]
+    public void PromptManager_ListPromptFileNamesWithVersions_ReturnsListOfPromptFileNamesAndVersions()
+    {
+        var manager = new PromptManager();
+        
+        var expectedPrompts = new List<string> { "basic:1", "example-with-name:1" };
+        var actualPrompts = manager.ListPromptFileNamesWithVersions().ToList();
+        
+        Assert.Equal(expectedPrompts.Count, actualPrompts.Count);
+        foreach (var expectedPrompt in expectedPrompts)
+        {
+            Assert.Contains(expectedPrompt, actualPrompts);
+        }
+    }
 
     [Fact]
     public void PromptManager_WithDuplicateNames_ThrowsException()

--- a/DotPrompt.Tests/multiple-version-prompts/basic-new.prompt
+++ b/DotPrompt.Tests/multiple-version-prompts/basic-new.prompt
@@ -1,0 +1,20 @@
+name: basic
+version: 2
+config:
+  outputFormat: text
+  temperature: 0.9
+  maxTokens: 500
+  input:
+    parameters:
+      country: string
+      style?: string
+    default:
+      country: Malta
+prompts:
+  system: |
+    You are a helpful AI assistant that enjoys making capybara related puns. You should work as many into your response as possible
+  user: |
+    I am looking at going on holiday to {{ country }} and would like to know more about it, what can you tell me?
+    {% if style -%}
+    Can you answer in the style of a {{ style }}
+    {% endif -%}

--- a/DotPrompt.Tests/multiple-version-prompts/basic.prompt
+++ b/DotPrompt.Tests/multiple-version-prompts/basic.prompt
@@ -1,0 +1,20 @@
+name: basic
+version: 1
+config:
+  outputFormat: text
+  temperature: 0.9
+  maxTokens: 500
+  input:
+    parameters:
+      country: string
+      style?: string
+    default:
+      country: Malta
+prompts:
+  system: |
+    You are a helpful AI assistant that enjoys making penguin related puns. You should work as many into your response as possible
+  user: |
+    I am looking at going on holiday to {{ country }} and would like to know more about it, what can you tell me?
+    {% if style -%}
+    Can you answer in the style of a {{ style }}
+    {% endif -%}

--- a/DotPrompt/DotPrompt.csproj
+++ b/DotPrompt/DotPrompt.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluid.Core" Version="2.23.0" />
-    <PackageReference Include="JsonSchema.Net" Version="7.3.4" />
-    <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="Fluid.Core" Version="2.25.0" />
+    <PackageReference Include="JsonSchema.Net" Version="7.4.0" />
+    <PackageReference Include="OpenAI" Version="2.3.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   

--- a/DotPrompt/PromptFile.cs
+++ b/DotPrompt/PromptFile.cs
@@ -24,6 +24,11 @@ public partial class PromptFile
     public required string Name { get; set; }
     
     /// <summary>
+    /// Gets, sets the version of the prompt file.
+    /// </summary>
+    public int Version { get; set; } = 1;
+    
+    /// <summary>
     /// Gets, sets the name of the model (or deployment) the prompt should be executed using
     /// </summary>
     public string? Model { get; set; }
@@ -112,6 +117,12 @@ public partial class PromptFile
         if (string.IsNullOrEmpty(promptFile.Name))
         {
             promptFile.Name = name;
+        }
+        
+        // If the prompt version is negative, then throw an exception
+        if (promptFile.Version < 0)
+        {
+            throw new DotPromptException("The version of the prompt file cannot be negative");
         }
 
         // If the prompt output configuration is null then create a new one and set the output format. This is to handle

--- a/DotPrompt/PromptManager.cs
+++ b/DotPrompt/PromptManager.cs
@@ -3,11 +3,18 @@ using System.Collections.Concurrent;
 namespace DotPrompt;
 
 /// <summary>
+/// Identifies a .prompt file uniquely using its name and version
+/// </summary>
+/// <param name="Name">The name of the prompt file</param>
+/// <param name="Version">The prompt file version</param>
+public record PromptFileIdentifier(string Name, int Version);
+
+/// <summary>
 /// Manages loading and accessing of .prompt files from a specified directory.
 /// </summary>
 public class PromptManager : IPromptManager
 {
-    private readonly ConcurrentDictionary<string, PromptFile> _promptFiles = new();
+    private readonly ConcurrentDictionary<PromptFileIdentifier, PromptFile> _promptFiles = new();
     
     /// <summary>
     /// Creates a new instance of the <see cref="PromptManager"/> using a default instance of the
@@ -30,35 +37,67 @@ public class PromptManager : IPromptManager
     {
         foreach (var promptFile in promptStore.Load())
         {
-            if (!_promptFiles.TryAdd(promptFile.Name, promptFile))
+            if (!_promptFiles.TryAdd(new PromptFileIdentifier(promptFile.Name, promptFile.Version), promptFile))
             {
-                throw new DotPromptException($"Unable to add prompt file with name '{promptFile.Name}' as a duplicate exists");
+                throw new DotPromptException($"Unable to add prompt file with name '{promptFile.Name}' and version {promptFile.Version} as a duplicate exists");
             }
         }
     }
 
     /// <summary>
-    /// Retrieves a <see cref="PromptFile"/> by its name
+    /// Retrieves a <see cref="PromptFile"/> by its name. If multiple versions of the prompt file are found, the
+    /// latest version is returned.
     /// </summary>
     /// <param name="name">The name of the prompt file to retrieve</param>
     /// <returns>The <see cref="PromptFile"/> with the specified name</returns>
     /// <exception cref="DotPromptException">Thrown when no prompt file with the specified name is found</exception>
     public PromptFile GetPromptFile(string name)
     {
-        if (_promptFiles.TryGetValue(name, out var promptFile)) 
-        {
-            return promptFile;
-        }
+        var promptFilesWithName = _promptFiles
+            .Where(kvp => kvp.Key.Name == name)
+            .OrderByDescending(kvp => kvp.Key.Version)
+            .ToList();
 
-        throw new DotPromptException("No prompt file with that name has been loaded");
+        return promptFilesWithName.Count == 0
+            ? throw new DotPromptException("No prompt file with that name has been loaded")
+            : promptFilesWithName[0].Value;
     }
 
+    /// <summary>
+    /// Retrieves a <see cref="PromptFile"/> by its name and version.
+    /// </summary>
+    /// <param name="name">The name of the prompt file to retrieve</param>
+    /// <param name="version">The version of the prompt file to retrieve</param>
+    /// <returns>The <see cref="PromptFile"/> with the specified name and version</returns>
+    /// <exception cref="DotPromptException">Thrown when no prompt file with the specified name and version is found</exception>
+    public PromptFile GetPromptFile(string name, int version)
+    {
+        return _promptFiles.TryGetValue(new PromptFileIdentifier(name, version), out var promptFile)
+            ? promptFile
+            : throw new DotPromptException("No prompt file with that name and version has been loaded");
+    }
+    
     /// <summary>
     /// Lists the names of all loaded prompt files.
     /// </summary>
     /// <returns>An enumerable collection of prompt file names.</returns>
     public IEnumerable<string> ListPromptFileNames()
     {
-        return _promptFiles.Keys.Select(k => k);
+        return _promptFiles
+            .DistinctBy(kvp => kvp.Key.Name)
+            .OrderBy(kvp => kvp.Key.Name)
+            .Select(kvp => $"{kvp.Key.Name}");
+    }
+
+    /// <summary>
+    /// Lists the names of all loaded prompts with their versions.
+    /// </summary>
+    /// <returns>An enumerable collection of prompt file names and versions.</returns>
+    public IEnumerable<string> ListPromptFileNamesWithVersions()
+    {
+        return _promptFiles
+            .OrderBy(kvp => kvp.Key.Name)
+            .ThenByDescending(kvp => kvp.Key.Version)
+            .Select(kvp => $"{kvp.Key.Name}:{kvp.Key.Version}");
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A complete prompt file would look like this.
 
 ```yaml
 name: Example
+version: 1
 model: gpt-4o
 config:
   outputFormat: text
@@ -70,6 +71,10 @@ config:
 The `name` is optional in the configuration, if it's not provided then the name is taken from the file name minus the extension. So a file called `gen-lookup-code.prompt` would get the name `gen-lookup-code`. This doesn't play a role in the generation of the prompts themselves (though future updates might), but allows you to identify the prompt source when logging, and to select the prompt from the prompt manager.
 
 If you use this property then when the file is loaded the name is converted to lowercase and spaces are replaced with hyphens. So a name of `My cool Prompt` would become `my-cool-prompt`. This is done to make sure the name is easily accessible from the code.
+
+### Version
+
+The `version` is optional in the configuration, if it's not provided then the version is set to `1`. This is used to allow you to update the prompt file without breaking existing code. Different versions can be loaded by specifying the version number when loading the prompt file through the prompt manager. If no version is specified then the latest version is loaded.
 
 ### Model
 
@@ -210,6 +215,9 @@ var promptFile = promptManager.GetPromptFile("example");
 var promptManager = new PromptManager("another-location");
 
 var promptFile = promptManager.GetPromptFile("example");
+
+// Loading a specific version
+// var promptFile = promptManager.GetPromptFile("example", 2);
 
 // List all of the prompts loaded
 var promptNames = promptManager.ListPromptFileNames();

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage: 
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3%
+    patch:
+      default:
+        target: auto
+        threshold: 3%


### PR DESCRIPTION
Adds support for version numbers to the prompt file allowing for handling of different versions of the prompt

Added codecov.yml file to stop the builds from being so aggressive in their coverage evaluation